### PR TITLE
feat: add persistentvolumes and persistentvolumesclaim resources

### DIFF
--- a/templates/loader/_all.tpl
+++ b/templates/loader/_all.tpl
@@ -15,6 +15,8 @@ Main entrypoint for the common library chart. It will render all underlying temp
   {{- include "common-helm-library.resources.ingress" . }}
   {{- include "common-helm-library.resources.storageClass" . }}
   {{- include "common-helm-library.resources.secret" . }}
+  {{- include "common-helm-library.resources.persistentVolume" . }}
+  {{- include "common-helm-library.resources.persistentVolumeClaim" . }}
   {{- include "common-helm-library.extensions.postgres.cluster" . }}
   {{- include "common-helm-library.extensions.prometheus.serviceMonitor" . }}
   {{- include "common-helm-library.extensions.certManager.certificate" . }}

--- a/templates/resources/persistentVolume.tpl
+++ b/templates/resources/persistentVolume.tpl
@@ -1,0 +1,47 @@
+{{- define "common-helm-library.resources.persistentVolume" }}
+{{- if .Values.persistentVolume.enabled }}
+{{- with .Values.persistentVolume }}
+{{- range .volumes }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "common-helm-library.helpers.metadata.commonLabels" $ | indent 4 }}
+    {{- include "common-helm-library.helpers.metadata.resourceLabels" . | indent 4 }}
+  annotations:
+    {{- include "common-helm-library.helpers.metadata.commonAnnotations" $ | indent 4 }}
+    {{- include "common-helm-library.helpers.metadata.resourceAnnotations" . | indent 4 }}
+spec:
+  capacity:
+    storage: {{ .capacity }}
+  accessModes:
+  {{- range .accessModes }}
+    - {{ . }}
+  {{- end }}
+  {{- if .storageClass }}
+  storageClassName: {{ .storageClass }}
+  {{- end }}
+  {{- if .hostPath }}
+  hostPath:
+    path: {{ .hostPath }}
+  {{- end }}
+  {{- if .nfs }}
+  nfs:
+    server: {{ .nfs.server }}
+    path: {{ .nfs.path }}
+    {{- if .nfs.readOnly }}
+    readOnly: {{ .nfs.readOnly }}
+    {{- end }}
+  {{- end }}
+  {{- if .claim }}
+  claimRef:
+    name: {{ .claim.name }}
+    namespace: {{ .claim.namespace }}
+  {{- end }}
+  persistentVolumeReclaimPolicy: {{ .persistentVolumeReclaimPolicy }}
+---
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/resources/persistentVolumeClaim.tpl
+++ b/templates/resources/persistentVolumeClaim.tpl
@@ -1,0 +1,41 @@
+{{- define "common-helm-library.resources.persistentVolumeClaim" -}}
+{{- if .Values.persistentVolumeClaim.enabled }}
+{{- with .Values.persistentVolumeClaim }}
+{{- range .volumes }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "common-helm-library.helpers.metadata.commonLabels" $ | indent 4 }}
+    {{- include "common-helm-library.helpers.metadata.resourceLabels" . | indent 4 }}
+  annotations:
+    {{- include "common-helm-library.helpers.metadata.commonAnnotations" $ | indent 4 }}
+    {{- include "common-helm-library.helpers.metadata.resourceAnnotations" . | indent 4 }}
+spec:
+  accessModes:
+  {{- range .accessModes }}
+    - {{ . }}
+  {{- end }}
+  {{- if .volumeMode }}
+  volumeMode: {{ .volumeMode }}
+  {{- end }}
+  {{- if .volumeName }}
+  volumeName: {{ .volumeName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .capacity }}
+  {{- if .storageClass }}
+  storageClassName: {{ .storageClass }}
+  {{- end }}
+  {{- if .selector }}
+selector:
+  matchLabels:
+    {{- toYaml .selector.matchLabels | nindent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -323,6 +323,40 @@ storageClass:
   parameters: []
   mountOptions: []
 
+persistentVolume:
+  enabled: false
+#  volumes: []
+#    - name: ""
+#      annotations: {}
+#      labels: {}
+#      capacity: ""
+#      accessModes: []
+#      persistentVolumeReclaimPolicy: ""
+#      storageClass: ""
+#      hostPath: ""
+#      nfs:
+#        server: ""
+#        path: ""
+#        readonly: ""
+#      claim:
+#        name: {}
+#        namespace: {}
+
+
+persistentVolumeClaim:
+  enabled: false
+#  volumes: []
+#    - name: ""
+#      annotations: {}
+#      labels: {}
+#      accessModes: []
+#      volumeMode: {}
+#      volumeName: {}
+#      capacity: {}
+#      storageClass: {}
+#      selector:
+#        matchlabels: {}
+
 rbac:
   enabled: false
   roles: {}


### PR DESCRIPTION
This change introduces the  persistentVolume and persistentVolumeClaim resources to the common-helm-chart

Aligned with existing standard

Applied feedback provided form code owner on alignment to existing standards and removal of list as range is being used to manage multiple of the same resource type.