### PR TITLE
fix: include port protocol if provided in exposed ports of workload.

### DIFF
--- a/templates/helpers/workload/ports.tpl
+++ b/templates/helpers/workload/ports.tpl
@@ -11,6 +11,9 @@ ports:
   {{- range .ports }}
   - name: {{ .name }}
     containerPort: {{ .port }}
+    {{- if .protocol }}
+    protocol: {{ .protocol }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
When exposing the same port over TCP and UDP the deployment fails for duplication. This is caused by the protocol not being passed to the deployment.

If no protocol is provided default is TCP as per the original behaviour