### PR TITLE
feat: optional bypass value for default env

### DIFF
--- a/templates/helpers/workload/envs.tpl
+++ b/templates/helpers/workload/envs.tpl
@@ -1,41 +1,35 @@
 {{- define "common-helm-library.helpers.workload.envs" }}
 env:
-  - name: NAME
+  {{- $standardVars := list
+    (dict "name" "NAME" "fieldPath" "metadata.name")
+    (dict "name" "POD_NAME" "fieldPath" "metadata.name")
+    (dict "name" "NAMESPACE" "fieldPath" "metadata.namespace")
+    (dict "name" "POD_NAMESPACE" "fieldPath" "metadata.namespace")
+    (dict "name" "OPERATOR_NAMESPACE" "fieldPath" "metadata.namespace")
+    (dict "name" "HOST_IP_ADDRESS" "fieldPath" "status.hostIP")
+    (dict "name" "HOSTNAME" "fieldPath" "spec.nodeName")
+    (dict "name" "NODE_NAME" "fieldPath" "spec.nodeName")
+    (dict "name" "POD_IP" "fieldPath" "status.podIP")
+  }}
+  {{- $disableDefaultEnv := .disableDefaultEnv | default list }}
+
+  {{- range $standardVars }}
+    {{- $varName := .name }}
+    {{- $isDisabled := false }}
+    {{- range $disableDefaultEnv }}
+      {{- if eq $varName . }}
+        {{- $isDisabled = true }}
+        {{- break }}
+      {{- end }}
+    {{- end }}
+    {{- if not $isDisabled }}
+  - name: {{ $varName }}
     valueFrom:
       fieldRef:
-        fieldPath: metadata.name
-  - name: POD_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.name
-  - name: NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
-  - name: POD_NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
-  - name: OPERATOR_NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
-  - name: HOST_IP_ADDRESS
-    valueFrom:
-      fieldRef:
-        fieldPath: status.hostIP
-  - name: HOSTNAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-  - name: NODE_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-  - name: POD_IP
-    valueFrom:
-      fieldRef:
-        fieldPath: status.podIP
+        fieldPath: {{ .fieldPath }}
+    {{- end }}
+  {{- end }}
+
   {{- range .envs }}
   - name: {{ .name }}
     value: {{ .value | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -36,6 +36,9 @@ workload:
   # -- Arguments to pass to the main workload
   args: []
 
+  # -- Disable selective default env variables
+  disableDefaultEnv: {}
+
   # -- Environment Variables to mount into pod
   envs: []
     # - name: EXAMPLE_ENV


### PR DESCRIPTION
This feature is an optional bypass for the existing default env records provided by workload helper.

The existing behaviour of env is unchanged, only providing the  disableDefaultEnv value with a list of names will cause any of the default env to be removed.

This has been tested on a application where I needed to override the HOSTNAME default with a custom record.