### PR TITLE
feat: add version-checker support

### DIFF
--- a/templates/helpers/metadata/commonAnnotations.tpl
+++ b/templates/helpers/metadata/commonAnnotations.tpl
@@ -1,5 +1,8 @@
 {{- define "common-helm-library.helpers.metadata.commonAnnotations" }}
 app.kubernetes.io/name: {{ .Release.Name }}
+{{- if .Values.versionChecker.imageOverride }}
+override-url.version-checker.io/{{ .Release.Name }}: {{ .Values.workload.image.registry }}/{{ .Values.workload.image.repository }}
+{{- end }}
 {{- with .Values.global.annotations }}
 {{- toYaml . | nindent 0 }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -523,4 +523,7 @@ postgres:
   version: {}
   size: {}
 
+versionChecker:
+  imageOverride: false
+
 extraObjects: []


### PR DESCRIPTION
Adds support for [version-checker](https://github.com/jetstack/version-checker) to allow users to add the annotation to override what repository version-checker checks, handy if using tools such as [kuik](https://github.com/enix/kube-image-keeper)