### PR TITLE
fix: no hpa on daemonset

### DIFF
--- a/templates/resources/horizontalPodAutoscaler.tpl
+++ b/templates/resources/horizontalPodAutoscaler.tpl
@@ -1,5 +1,5 @@
 {{- define "common-helm-library.resources.horizontalPodAutoscaler" }}
-{{- if .Values.autoscaling.enabled }}
+{{- if and .Values.autoscaling.enabled (ne .Values.workload.type "DaemonSet") }}
 {{- with .Values.autoscaling }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
Horizontal pod autoscaling does not apply to objects that can't be scaled i.e DaemonSet