### PR TITLE
fix: stop version checker annotation applying globally

### DIFF
--- a/templates/helpers/metadata/commonAnnotations.tpl
+++ b/templates/helpers/metadata/commonAnnotations.tpl
@@ -1,8 +1,5 @@
 {{- define "common-helm-library.helpers.metadata.commonAnnotations" }}
 app.kubernetes.io/name: {{ .Release.Name }}
-{{- if .Values.versionChecker.imageOverride }}
-override-url.version-checker.io/{{ .Release.Name }}: {{ .Values.workload.image.registry }}/{{ .Values.workload.image.repository }}
-{{- end }}
 {{- with .Values.global.annotations }}
 {{- toYaml . | nindent 0 }}
 {{- end }}

--- a/templates/resources/workload.tpl
+++ b/templates/resources/workload.tpl
@@ -11,6 +11,9 @@ metadata:
   annotations:
     {{- include "common-helm-library.helpers.metadata.commonAnnotations" $ | indent 4 }}
     {{- include "common-helm-library.helpers.metadata.resourceAnnotations" . | indent 4 }}
+    {{- if $.Values.versionChecker.imageOverride }}
+    override-url.version-checker.io/{{ $.Release.Name }}: {{ .image.registry }}/{{ .repository }}
+    {{- end }}
 spec:
   {{- include "common-helm-library.helpers.workload.replicas" . | indent 2 }}
   {{- include "common-helm-library.helpers.workload.serviceName" $ | indent 2 }}


### PR DESCRIPTION
Currently version checker is applying the annotation is all resources rather just the pod